### PR TITLE
Feat: #21 카카오 로그인 연동 로직 구현

### DIFF
--- a/src/main/java/com/example/timefit/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/timefit/domain/user/controller/AuthController.java
@@ -4,19 +4,29 @@ import com.example.timefit.domain.user.dto.LoginRequest;
 import com.example.timefit.domain.user.dto.LoginResponse;
 import com.example.timefit.domain.user.service.AuthService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
-  
+
   private final AuthService authService;
 
   @PostMapping("/login")
   public ResponseEntity<LoginResponse> socialLogin(@RequestBody LoginRequest request) {
+    log.info("[AuthController] 로그인 요청 수신: provider={}, code={}", request.provider(), request.authorizationCode());
     LoginResponse response = authService.socialLogin(request);
+    return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/kakao/callback")
+  public ResponseEntity<LoginResponse> kakaoCallback(@RequestParam("code") String code) {
+    log.info("[AuthController] 인가코드 수신 (카카오): {}", code);
+    LoginResponse response = authService.kakaoLogin(code);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/example/timefit/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/UserResponse.java
@@ -6,9 +6,10 @@ public record UserResponse (
   Long id,
   String socialId,
   String nickname,
-  String profileImage
+  String profileImage,
+  String provider
 ) {
   public UserResponse(User user) {
-    this(user.getId(), user.getSocialId(), user.getNickname(), user.getProfileImage());
+    this(user.getId(), user.getSocialId(), user.getNickname(), user.getProfileImage(), user.getProvider());
   }
 }

--- a/src/main/java/com/example/timefit/domain/user/service/AuthService.java
+++ b/src/main/java/com/example/timefit/domain/user/service/AuthService.java
@@ -15,19 +15,25 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class AuthService {
 
-  private final List<SocialLoginService> socialLoginServices;
-  
-  public LoginResponse socialLogin(LoginRequest request) {
-    String provider = request.provider().toLowerCase();
-    String code = request.authorizationCode();
+    private final List<SocialLoginService> socialLoginServices;
 
-    log.info("[AuthService] 로그인 요청 - provider: {}, code: {}", provider, code);
-    
-    SocialLoginService service = socialLoginServices.stream()
-            .filter(s -> s.getProviderName().equals(provider))
-            .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 로그인 방식입니다: " + provider));
-            
-    return service.login(code);
-  }
+    public LoginResponse socialLogin(LoginRequest request) {
+        String provider = request.provider().toLowerCase();
+        String code = request.authorizationCode();
+        log.info("[AuthService] [LOGIN_REQUEST] provider={}, code={}", provider, code);
+
+        return getService(provider).login(code);
+    }
+
+    public LoginResponse kakaoLogin(String authorizationCode) {
+        log.info("[AuthService] [KAKAO_CALLBACK] code={}", authorizationCode);
+        return getService("kakao").login(authorizationCode);
+    }
+
+    private SocialLoginService getService(String provider) {
+        return socialLoginServices.stream()
+                .filter(s -> s.getProviderName().equalsIgnoreCase(provider))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("[AuthService] 지원되지 않는 로그인 서비스: " + provider));
+    }
 }

--- a/src/main/java/com/example/timefit/domain/user/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/timefit/domain/user/service/KakaoOAuthService.java
@@ -1,12 +1,39 @@
 package com.example.timefit.domain.user.service;
 
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
 import com.example.timefit.domain.user.dto.LoginResponse;
+import com.example.timefit.domain.user.dto.UserResponse;
+
 import lombok.extern.slf4j.Slf4j;
+
 
 @Slf4j
 @Service
 public class KakaoOAuthService implements SocialLoginService {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${oauth.kakao.client-id}")
+    private String clientId;
+
+    @Value("${oauth.kakao.redirect-uri}")
+    private String redirectUri;
+
+    @Value("${oauth.kakao.client-secret:}")
+    private String clientSecret;
 
     @Override
     public String getProviderName() {
@@ -16,7 +43,72 @@ public class KakaoOAuthService implements SocialLoginService {
     @Override
     public LoginResponse login(String authorizationCode) {
         log.info("[KakaoOAuthService] 인가코드로 카카오 로그인 진행 - code: {}", authorizationCode);
-        // TODO: 카카오 API 연동 로직 추가
-        return new LoginResponse(null, null, null);
+        
+        String tokenUrl = "https://kauth.kakao.com/oauth/token";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", authorizationCode);
+        if (clientSecret != null && !clientSecret.isEmpty()) {
+            params.add("client_secret", clientSecret);
+        }
+
+        HttpEntity<MultiValueMap<String, String>> tokenRequest = new HttpEntity<>(params, headers);
+        ResponseEntity<Map<String, Object>> tokenResponse = restTemplate.exchange(
+                tokenUrl,
+                HttpMethod.POST,
+                tokenRequest,
+                new ParameterizedTypeReference<Map<String, Object>>() {}
+        );
+
+        Map<String, Object> tokenBody = tokenResponse.getBody();
+        if (!tokenResponse.getStatusCode().is2xxSuccessful() || tokenBody == null) {
+            throw new IllegalStateException("카카오 토큰 요청 실패: " + tokenResponse.getStatusCode());
+        }
+
+        String accessToken = (String) tokenBody.get("access_token");
+        String refreshToken = (String) tokenBody.get("refresh_token");
+        log.info("[KakaoOAuthService] Token 발급 완료 (access={}, refresh={})", accessToken, refreshToken);
+
+        String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
+        HttpHeaders userHeaders = new HttpHeaders();
+        userHeaders.setBearerAuth(accessToken);
+        HttpEntity<Void> userRequest = new HttpEntity<>(userHeaders);
+
+        ResponseEntity<Map<String, Object>> userResponse = restTemplate.exchange(
+                userInfoUrl,
+                HttpMethod.GET,
+                userRequest,
+                new ParameterizedTypeReference<Map<String, Object>>() {}
+        );
+
+        Map<String, Object> responseBody = userResponse.getBody();
+        if (!userResponse.getStatusCode().is2xxSuccessful() || responseBody == null) {
+            throw new IllegalStateException("카카오 사용자 정보 요청 실패: " + userResponse.getStatusCode());
+        }
+
+        Long kakaoId = responseBody.get("id") != null ? ((Number) responseBody.get("id")).longValue() : null;
+        String socialId = kakaoId != null ? "kakao_" + kakaoId : "kakao_unknown";
+
+        Map<String, Object> properties = safeCast(responseBody.get("properties"));
+        String nickname = properties != null ? (String) properties.getOrDefault("nickname", "카카오 사용자") : "카카오 사용자";
+        String profileImage = properties != null ? (String) properties.getOrDefault("profile_image", null) : null;
+
+        log.info("[KakaoOAuthService] 사용자 닉네임: {}, socialId: {}", nickname, socialId);
+
+        UserResponse user = new UserResponse(null, socialId, nickname, profileImage, getProviderName());
+        return new LoginResponse(accessToken, refreshToken, user);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> safeCast(Object obj) {
+        if (obj instanceof Map<?, ?> map) {
+            return (Map<String, Object>) map;
+        }
+        return null;
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,6 @@ spring.datasource.username=sa
 spring.jpa.hibernate.ddl-auto=update
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
+
+oauth.kakao.client-id=f939f9e98e824f5ce7592923a30ed35c
+oauth.kakao.redirect-uri=http://localhost:8080/api/auth/kakao/callback


### PR DESCRIPTION
## 📋 변경 사항

<!-- 어떤 변경사항이 있는지 간단히 설명해주세요 -->
인가코드를 받아 카카오 api를 통해 access token을 발급하고, 사용자 정보를 조회했습니다

## 🔗 관련 이슈

Closes #21 

## 📝 작업 내용

- [ ] 콜백 엔드포인트 추가
- [ ] AuthService에서 provider별 소셜 로그인 서비스 라우팅 로직 구현
- [ ] KakaoOAuthService: 인가코드를 받아 토큰 발급하고 사용자 정보 조회 로직 구현
- [ ] UserResponse에서 provider 필드 추가

## 💡 참고사항 (선택)

<!-- 테스트 결과, 스크린샷, 리뷰 포인트, 참고 자료 등 추가 정보가 있다면 자유롭게 작성해주세요 -->
현재 DB 연동 로직을 안 짜서, id는 null로 반환했습니다.
<img width="1063" height="233" alt="image" src="https://github.com/user-attachments/assets/34da5226-7f69-4374-83d5-8b97d67d88f9" />

api명세서랑 제 코드와 로그인 요청 처리 방식에 차이점이 있는 것 같은데
바꿔보려다가 너무 모르겠어서 일단 pr 올립니다
리뷰 부탁드립니다!
