### PR TITLE
Feat/#45 프로필 정보 확장 및 내 정보 수정 기능 구현

### DIFF
--- a/src/main/java/com/example/timefit/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/timefit/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.example.timefit.domain.user.controller;
 
 import com.example.timefit.domain.user.dto.UserResponse;
+import com.example.timefit.domain.user.dto.UserUpdateRequest;
 import com.example.timefit.domain.user.entity.User;
 import com.example.timefit.domain.user.service.UserService;
 
@@ -8,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,10 +24,22 @@ public class UserController {
     @GetMapping("/me")
     public ResponseEntity<UserResponse> getMyInfo(Authentication authentication) {
 
-        Long userId = (Long) authentication.getPrincipal();
+        Long userId = Long.valueOf(authentication.getName());
 
         User user = userService.getUserById(userId);
 
         return ResponseEntity.ok(new UserResponse(user));
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<UserResponse> updateMyInfo(
+        Authentication authentication,
+        @RequestBody UserUpdateRequest request
+    ) {
+        Long userId = Long.valueOf(authentication.getName());
+
+        User updatedUser = userService.updateMyInfo(userId, request);
+
+        return ResponseEntity.ok(new UserResponse(updatedUser));
     }
 }

--- a/src/main/java/com/example/timefit/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/timefit/domain/user/controller/UserController.java
@@ -38,8 +38,15 @@ public class UserController {
     ) {
         Long userId = Long.valueOf(authentication.getName());
 
-        User updatedUser = userService.updateMyInfo(userId, request);
+        if(request.nickname() != null) {
+            userService.updateNickname(userId, request.nickname());
+        }
 
-        return ResponseEntity.ok(new UserResponse(updatedUser));
+        if(request.profileImageUrl() != null) {
+            userService.updateProfileImage(userId, request.profileImageUrl());
+        }
+
+        User user = userService.getUserById(userId);
+        return ResponseEntity.ok(new UserResponse(user));
     }
 }

--- a/src/main/java/com/example/timefit/domain/user/dto/UserRequest.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/UserRequest.java
@@ -1,5 +1,0 @@
-package com.example.timefit.domain.user.dto;
-
-public class UserRequest {
-  
-}

--- a/src/main/java/com/example/timefit/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/UserResponse.java
@@ -4,10 +4,11 @@ import com.example.timefit.domain.user.entity.User;
 
 public record UserResponse (
   Long id,
-  String socialId,
-  String provider
+  String nickname,
+  String provider,
+  String profileImageUrl
 ) {
   public UserResponse(User user) {
-    this(user.getId(), user.getSocialId(), user.getProvider());
+    this(user.getId(), user.getNickname(), user.getProvider(), user.getProfileImageUrl());
   }
 }

--- a/src/main/java/com/example/timefit/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/UserUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.example.timefit.domain.user.dto;
+
+public record UserUpdateRequest(
+    String nickname,
+    String profileImageUrl
+) {}

--- a/src/main/java/com/example/timefit/domain/user/entity/User.java
+++ b/src/main/java/com/example/timefit/domain/user/entity/User.java
@@ -28,15 +28,35 @@ public class User {
   @Column(nullable = false)
   private String provider;
 
+  @Column(nullable = false)
+  private String nickname;
+
+  @Column
+  private String profileImageUrl;
+
   @Column(updatable = false)
   private LocalDateTime createdAt;
 
   @Column
   private LocalDateTime updatedAt;
 
-  public User(String socialId, String provider) {
+  public User(String socialId, String provider, String nickname) {
     this.socialId = socialId;
     this.provider = provider;
+    this.nickname = nickname;
+  }
+
+  public void updateProfile(String nickname, String profileImageUrl) {
+    if (nickname == null || nickname.isBlank()) {
+        throw new IllegalArgumentException("nickname은 필수입니다.");
+    }
+    this.nickname = nickname;
+
+    if (profileImageUrl != null) {
+      this.profileImageUrl = profileImageUrl;
+    }
+
+    this.updatedAt = LocalDateTime.now();
   }
 
 }

--- a/src/main/java/com/example/timefit/domain/user/entity/User.java
+++ b/src/main/java/com/example/timefit/domain/user/entity/User.java
@@ -46,16 +46,16 @@ public class User {
     this.nickname = nickname;
   }
 
-  public void updateProfile(String nickname, String profileImageUrl) {
+  public void updateNickname(String nickname) {
     if (nickname == null || nickname.isBlank()) {
-        throw new IllegalArgumentException("nickname은 필수입니다.");
+      throw new IllegalArgumentException("nickname은 필수입니다.");
     }
     this.nickname = nickname;
+    this.updatedAt = LocalDateTime.now();
+  }
 
-    if (profileImageUrl != null) {
-      this.profileImageUrl = profileImageUrl;
-    }
-
+  public void updateProfileImage(String profileImageUrl) {
+    this.profileImageUrl = profileImageUrl;
     this.updatedAt = LocalDateTime.now();
   }
 

--- a/src/main/java/com/example/timefit/domain/user/oauth/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/example/timefit/domain/user/oauth/GoogleOAuth2UserInfo.java
@@ -21,6 +21,11 @@ public class GoogleOAuth2UserInfo implements OAuth2UserInfo {
     }
 
     @Override
+    public String getNickname() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
     public Map<String, Object> getAttributes() {
         return attributes;
     }

--- a/src/main/java/com/example/timefit/domain/user/oauth/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/example/timefit/domain/user/oauth/KakaoOAuth2UserInfo.java
@@ -20,6 +20,21 @@ public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
     }
 
     @Override
+    public String getNickname() {
+        Map<String, Object> kakaoAccount =
+                (Map<String, Object>) attributes.get("kakao_account");
+
+        if (kakaoAccount == null) return null;
+
+        Map<String, Object> profile =
+                (Map<String, Object>) kakaoAccount.get("profile");
+
+        if (profile == null) return null;
+
+        return (String) profile.get("nickname");
+    }
+
+    @Override
     public Map<String, Object> getAttributes() {
         return attributes;
     }

--- a/src/main/java/com/example/timefit/domain/user/oauth/OAuth2UserInfo.java
+++ b/src/main/java/com/example/timefit/domain/user/oauth/OAuth2UserInfo.java
@@ -6,6 +6,6 @@ public interface OAuth2UserInfo {
 
     String getProvider();
     String getSocialId();
-
+    String getNickname();
     Map<String, Object> getAttributes();
 }

--- a/src/main/java/com/example/timefit/domain/user/service/AuthService.java
+++ b/src/main/java/com/example/timefit/domain/user/service/AuthService.java
@@ -78,14 +78,17 @@ public class AuthService {
 
     private LoginResponse loginWithKakao(String kakaoAccessToken) {
 
+        log.info("[AuthService] loginWithKakao start");
+
         KakaoOAuth2UserInfo userInfo =
                 kakaoOAuthService.getUserInfo(kakaoAccessToken);
-
+        
         User user = userRepository.findBySocialId(userInfo.getSocialId())
                 .orElseGet(() -> userRepository.save(
                         new User(
                                 userInfo.getSocialId(),
-                                userInfo.getProvider()
+                                userInfo.getProvider(),
+                                userInfo.getNickname()
                         )
                 ));
 
@@ -110,7 +113,8 @@ public class AuthService {
                 .orElseGet(() -> userRepository.save(
                         new User(
                                 userInfo.getSocialId(),
-                                userInfo.getProvider()
+                                userInfo.getProvider(),
+                                userInfo.getNickname()
                         )
                 ));
 

--- a/src/main/java/com/example/timefit/domain/user/service/UserService.java
+++ b/src/main/java/com/example/timefit/domain/user/service/UserService.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Service;
 
 import com.example.timefit.domain.user.entity.User;
 import com.example.timefit.domain.user.repository.UserRepository;
-import com.example.timefit.domain.user.dto.UserUpdateRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
@@ -23,14 +22,16 @@ public class UserService {
     }
 
     @Transactional
-    public User updateMyInfo(Long userId, UserUpdateRequest request) {
+    public User updateNickname(Long userId, String nickname) {
         User user = getUserById(userId);
+        user.updateNickname(nickname);
+        return user;
+    }
 
-        user.updateProfile(
-            request.nickname(),
-            request.profileImageUrl()
-        );
-
+    @Transactional
+    public User updateProfileImage(Long userId, String profileImageUrl) {
+        User user = getUserById(userId);
+        user.updateProfileImage(profileImageUrl);
         return user;
     }
 }

--- a/src/main/java/com/example/timefit/domain/user/service/UserService.java
+++ b/src/main/java/com/example/timefit/domain/user/service/UserService.java
@@ -4,6 +4,8 @@ import org.springframework.stereotype.Service;
 
 import com.example.timefit.domain.user.entity.User;
 import com.example.timefit.domain.user.repository.UserRepository;
+import com.example.timefit.domain.user.dto.UserUpdateRequest;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,5 +20,17 @@ public class UserService {
                 .orElseThrow(() ->
                         new IllegalArgumentException("해당 유저를 찾을 수 없습니다. userId=" + userId)
                 );
+    }
+
+    @Transactional
+    public User updateMyInfo(Long userId, UserUpdateRequest request) {
+        User user = getUserById(userId);
+
+        user.updateProfile(
+            request.nickname(),
+            request.profileImageUrl()
+        );
+
+        return user;
     }
 }


### PR DESCRIPTION
## 📋 변경 사항

<!-- 어떤 변경사항이 있는지 간단히 설명해주세요 -->
User 엔티티에 프로필 닉네임과 이미지 필드 추가
User 조회/수정 API 구조 정리

## 🔗 관련 이슈

Closes #45 

## 📝 작업 내용

- [ ] User 엔티티에 nickname, profileImageUrl 필드 추가
- [ ] UserUpdateRequest 추가
- [ ] UserService, UserController에 정보 수정 기능 추가

## 💡 참고사항 (선택)

<!-- 테스트 결과, 스크린샷, 리뷰 포인트, 참고 자료 등 추가 정보가 있다면 자유롭게 작성해주세요 -->
