### PR TITLE
RoomService의 Error 처리를 ErrorCode로 바꾸기

### DIFF
--- a/src/main/java/com/example/timefit/domain/exeption/ErrorCode.java
+++ b/src/main/java/com/example/timefit/domain/exeption/ErrorCode.java
@@ -7,8 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
-    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 방을 찾을 수 없습니다. id:"),
-    OWNER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다.");
+    ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 방을 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    OWNER_NOT_FOUND(HttpStatus.FORBIDDEN, "방의 소유자가 아닙니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/example/timefit/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/example/timefit/domain/room/repository/RoomRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
-    Room findByInviteCode(String inviteCode);
+    Optional<Room> findByInviteCode(String inviteCode);
 }

--- a/src/main/java/com/example/timefit/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/timefit/domain/room/service/RoomService.java
@@ -32,7 +32,7 @@ public class RoomService {
     @Transactional
     public RoomResponse createRoom(RoomCreateRequest request, Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("없는 유저입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         String newInviteCode = UUID.randomUUID().toString();
 
@@ -67,10 +67,10 @@ public class RoomService {
     @Transactional
     public RoomResponse updateRoom(Long roomId, RoomUpdateRequest request, Long userId) {
         Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 방입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("없는 유저입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         room.validateOwner(user);
 
@@ -90,7 +90,7 @@ public class RoomService {
     @Transactional
     public RoomDeleteMessage delete(Long roomId, Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("없는 유저입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         Room room = findRoomById(roomId);
         room.validateOwner(user);
@@ -102,13 +102,10 @@ public class RoomService {
     @Transactional(readOnly = true)
     public RoomResponse getRoomByInviteCode(String inviteCode, Long userId) {
         userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("없는 유저입니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        Room room = roomRepository.findByInviteCode(inviteCode);
-
-        if (room == null) {
-            throw new CustomException(ErrorCode.ROOM_NOT_FOUND);
-        }
+        Room room = roomRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
 
         return new RoomResponse(room);
     }


### PR DESCRIPTION
## 📋 변경 사항

에러 처리를 .orElseThrow(() . . . 식으로 날리기 위해 Repository의 inviteCode를 찾는 메서드를 optional로 바꿈
RoomService의 Error 처리를 ErrorCode로 바꿈

## 🔗 관련 이슈

Closes #51 

## 📝 작업 내용

- [ ] Repository의 inviteCode를 찾는 메서드를 optional로 바꿈
- [ ] RoomService의 Error 처리를 ErrorCode로 바꿈

## 💡 참고사항 (선택)

<!-- 테스트 결과, 스크린샷, 리뷰 포인트, 참고 자료 등 추가 정보가 있다면 자유롭게 작성해주세요 -->
