### PR TITLE
✨ Feat: 애플 로그인 기능 (#53)

### DIFF
--- a/src/main/java/com/example/timefit/domain/user/oauth/AppleOAuth2UserInfo.java
+++ b/src/main/java/com/example/timefit/domain/user/oauth/AppleOAuth2UserInfo.java
@@ -1,0 +1,47 @@
+package com.example.timefit.domain.user.oauth;
+
+import java.util.Map;
+
+public class AppleOAuth2UserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public AppleOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProvider() {
+        return "APPLE";
+    }
+
+    @Override
+    public String getSocialId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getNickname() {
+        return null;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    public Boolean isEmailVerified() {
+        Object emailVerified = attributes.get("email_verified");
+        if (emailVerified instanceof Boolean) {
+            return (Boolean) emailVerified;
+        }
+        if (emailVerified instanceof String) {
+            return Boolean.parseBoolean((String) emailVerified);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/example/timefit/domain/user/service/AppleOAuthService.java
+++ b/src/main/java/com/example/timefit/domain/user/service/AppleOAuthService.java
@@ -1,0 +1,89 @@
+package com.example.timefit.domain.user.service;
+
+import com.example.timefit.domain.user.oauth.AppleOAuth2UserInfo;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AppleOAuthService {
+
+    private static final String APPLE_KEYS_URL = "https://appleid.apple.com/auth/keys";
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public AppleOAuth2UserInfo getUserInfo(String identityToken) {
+        try {
+            String kid = extractKidFromToken(identityToken);
+            PublicKey publicKey = getApplePublicKey(kid);
+
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(identityToken)
+                    .getBody();
+
+            Map<String, Object> attributes = new HashMap<>(claims);
+
+            log.info("[AppleOAuthService] 애플 사용자 정보 조회 성공");
+
+            return new AppleOAuth2UserInfo(attributes);
+        } catch (Exception e) {
+            log.error("[AppleOAuthService] Identity Token 검증 실패", e);
+            throw new IllegalArgumentException("Invalid Apple Identity Token", e);
+        }
+    }
+
+    private String extractKidFromToken(String token) throws Exception {
+        String[] parts = token.split("\\.");
+        if (parts.length != 3) {
+            throw new IllegalArgumentException("Invalid JWT format");
+        }
+
+        String header = new String(Base64.getUrlDecoder().decode(parts[0]));
+        JsonNode headerNode = objectMapper.readTree(header);
+
+        return headerNode.get("kid").asText();
+    }
+
+    private PublicKey getApplePublicKey(String kid) throws Exception {
+        String response = restTemplate.getForObject(APPLE_KEYS_URL, String.class);
+        JsonNode keys = objectMapper.readTree(response).get("keys");
+
+        for (JsonNode key : keys) {
+            if (kid.equals(key.get("kid").asText())) {
+                String n = key.get("n").asText();
+                String e = key.get("e").asText();
+
+                byte[] nBytes = Base64.getUrlDecoder().decode(n);
+                byte[] eBytes = Base64.getUrlDecoder().decode(e);
+
+                BigInteger modulus = new BigInteger(1, nBytes);
+                BigInteger exponent = new BigInteger(1, eBytes);
+
+                RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+                KeyFactory factory = KeyFactory.getInstance("RSA");
+
+                return factory.generatePublic(spec);
+            }
+        }
+
+        throw new IllegalArgumentException("Apple public key not found for kid: " + kid);
+    }
+}

--- a/src/main/java/com/example/timefit/domain/user/service/AuthService.java
+++ b/src/main/java/com/example/timefit/domain/user/service/AuthService.java
@@ -4,6 +4,7 @@ import com.example.timefit.domain.user.entity.User;
 import com.example.timefit.domain.user.entity.RefreshToken;
 import com.example.timefit.domain.user.repository.UserRepository;
 import com.example.timefit.domain.user.repository.RefreshTokenRepository;
+import com.example.timefit.domain.user.oauth.AppleOAuth2UserInfo;
 import com.example.timefit.domain.user.oauth.KakaoOAuth2UserInfo;
 import com.example.timefit.domain.user.oauth.GoogleOAuth2UserInfo;
 import com.example.timefit.global.jwt.JwtTokenProvider;
@@ -17,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +27,7 @@ public class AuthService {
 
     private final KakaoOAuthService kakaoOAuthService;
     private final GoogleOAuthService googleOAuthService;
+    private final AppleOAuthService appleOAuthService;
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
@@ -34,6 +37,7 @@ public class AuthService {
         return switch (provider.toUpperCase()) {
             case "KAKAO" -> loginWithKakao(accessToken);
             case "GOOGLE" -> loginWithGoogle(accessToken);
+            case "APPLE" -> loginWithApple(accessToken);
             default -> throw new IllegalArgumentException("Unsupported provider: " + provider);
         };
     }
@@ -128,6 +132,36 @@ public class AuthService {
                 refreshToken,
                 new UserResponse(user)
         );
+    }
+
+    private LoginResponse loginWithApple(String identityToken) {
+
+        AppleOAuth2UserInfo userInfo =
+                appleOAuthService.getUserInfo(identityToken);
+
+        User user = userRepository.findBySocialId(userInfo.getSocialId())
+                .orElseGet(() -> userRepository.save(
+                        new User(
+                                userInfo.getSocialId(),
+                                userInfo.getProvider(),
+                                generateDefaultNickname()
+                        )
+                ));
+
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+
+        saveRefreshToken(user.getId(), refreshToken);
+
+        return new LoginResponse(
+                accessToken,
+                refreshToken,
+                new UserResponse(user)
+        );
+    }
+
+    private String generateDefaultNickname() {
+        return "사용자_" + UUID.randomUUID().toString().substring(0, 8);
     }
 
     private void saveRefreshToken(Long userId, String refreshToken) {


### PR DESCRIPTION
  ## 개요
  기존 카카오/구글 소셜 로그인 패턴을 따라 애플 로그인 기능 추가

  ## 변경 사항
  - `AppleOAuth2UserInfo` 구현체 추가
  - `AppleOAuthService` 구현 (Identity Token JWT 검증)
  - `AuthService`에 애플 로그인 분기 추가
  - 기본 닉네임 생성 로직 추가 (애플은 이름 미제공)

  ## 관련 이슈
  - closes #53