### PR TITLE
Feat/#55 참여자 시간 선택 및 시간표 결과 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/timefit/domain/room/controller/RoomController.java
+++ b/src/main/java/com/example/timefit/domain/room/controller/RoomController.java
@@ -5,6 +5,7 @@ import com.example.timefit.domain.room.dto.RoomDeleteMessage;
 import com.example.timefit.domain.room.dto.RoomResponse;
 import com.example.timefit.domain.room.dto.RoomUpdateRequest;
 import com.example.timefit.domain.room.service.RoomService;
+import com.example.timefit.domain.room.dto.RoomDetailResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -59,6 +60,15 @@ public class RoomController {
             @AuthenticationPrincipal Long userId
     ) {
         RoomDeleteMessage response = roomService.delete(roomId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{roomId}")
+    public ResponseEntity<RoomDetailResponse> getRoomDetail(
+        @PathVariable Long roomId,
+        @AuthenticationPrincipal Long userId
+    ) {
+        RoomDetailResponse response = roomService.getRoomDetail(roomId, userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/timefit/domain/room/dto/RoomDetailResponse.java
+++ b/src/main/java/com/example/timefit/domain/room/dto/RoomDetailResponse.java
@@ -3,14 +3,12 @@ package com.example.timefit.domain.room.dto;
 import java.util.List;
 
 public record RoomDetailResponse(
-        Long roomId,
-        String title,
-        List<String> dates,
-        List<String> timeSlots,
-        boolean isOwner,
-        boolean hasResponded,
-        long totalParticipants,
-        long respondedCount
-        ) {
-
-}
+    Long roomId,
+    String title,
+    List<String> dates,
+    List<String> timeSlots,
+    boolean isOwner,
+    boolean hasResponded,
+    long totalParticipants,
+    long respondedCount
+) {}

--- a/src/main/java/com/example/timefit/domain/room/dto/RoomDetailResponse.java
+++ b/src/main/java/com/example/timefit/domain/room/dto/RoomDetailResponse.java
@@ -1,0 +1,14 @@
+package com.example.timefit.domain.room.dto;
+
+import java.util.List;
+
+public record RoomDetailResponse(
+  Long roomId,
+  String title,
+  List<String> dates,
+  List<String> timeSlots,
+  boolean isOwner,
+  boolean hasResponded,
+  long totalParticipants,
+  long respondedCount
+) {}

--- a/src/main/java/com/example/timefit/domain/room/dto/RoomDetailResponse.java
+++ b/src/main/java/com/example/timefit/domain/room/dto/RoomDetailResponse.java
@@ -3,12 +3,14 @@ package com.example.timefit.domain.room.dto;
 import java.util.List;
 
 public record RoomDetailResponse(
-  Long roomId,
-  String title,
-  List<String> dates,
-  List<String> timeSlots,
-  boolean isOwner,
-  boolean hasResponded,
-  long totalParticipants,
-  long respondedCount
-) {}
+        Long roomId,
+        String title,
+        List<String> dates,
+        List<String> timeSlots,
+        boolean isOwner,
+        boolean hasResponded,
+        long totalParticipants,
+        long respondedCount
+        ) {
+
+}

--- a/src/main/java/com/example/timefit/domain/room/dto/RoomResponse.java
+++ b/src/main/java/com/example/timefit/domain/room/dto/RoomResponse.java
@@ -12,36 +12,36 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public record RoomResponse(
-        String id,
-        String title,
-        String inviteCode,
-        String owner,
-        List<LocalDate> dates,
-        LocalTime startTime,
-        LocalTime endTime,
-        List<String> timelist,
-        String createdAt,
-        String updatedAt,
-        String expiresAt
+    String id,
+    String title,
+    String inviteCode,
+    String owner,
+    List<LocalDate> dates,
+    LocalTime startTime,
+    LocalTime endTime,
+    List<String> timelist,
+    String createdAt,
+    String updatedAt,
+    String expiresAt
 ) {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
     public RoomResponse(Room room) {
         this(
-                String.valueOf(room.getId()),
-                room.getTitle(),
-                room.getInviteCode(),
-                String.valueOf(room.getOwner().getId()),
-                room.getDates().stream()
-                        .map(RoomDate::getDate)
-                        .collect(Collectors.toList()),
-                room.getStartTime(),
-                room.getEndTime(),
-                generateTimeList(room.getStartTime(), room.getEndTime()),
-                room.getCreatedAt().toLocalDate().format(DATE_FORMATTER),
-                room.getUpdatedAt() == null ? null : room.getUpdatedAt().toLocalDate().format(DATE_FORMATTER),
-                room.getExpiresAt().toLocalDate().format(DATE_FORMATTER)
+            String.valueOf(room.getId()),
+            room.getTitle(),
+            room.getInviteCode(),
+            String.valueOf(room.getOwner().getId()),
+            room.getDates().stream()
+                .map(RoomDate::getDate)
+                .collect(Collectors.toList()),
+            room.getStartTime(),
+            room.getEndTime(),
+            generateTimeList(room.getStartTime(), room.getEndTime()),
+            room.getCreatedAt().toLocalDate().format(DATE_FORMATTER),
+            room.getUpdatedAt() == null ? null : room.getUpdatedAt().toLocalDate().format(DATE_FORMATTER),
+            room.getExpiresAt().toLocalDate().format(DATE_FORMATTER)
         );
     }
 

--- a/src/main/java/com/example/timefit/domain/room/dto/RoomResponse.java
+++ b/src/main/java/com/example/timefit/domain/room/dto/RoomResponse.java
@@ -45,7 +45,7 @@ public record RoomResponse(
         );
     }
 
-    private static List<String> generateTimeList(LocalTime startTime, LocalTime endTime) {
+    public static List<String> generateTimeList(LocalTime startTime, LocalTime endTime) {
         List<String> timelist = new ArrayList<>();
 
         if (startTime.isAfter(endTime)) {

--- a/src/main/java/com/example/timefit/domain/room/entity/Participant.java
+++ b/src/main/java/com/example/timefit/domain/room/entity/Participant.java
@@ -10,43 +10,43 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(
-  name = "participants",
-  uniqueConstraints = @UniqueConstraint(columnNames = {"room_id", "user_id"})
+        name = "participants",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"room_id", "user_id"})
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Participant {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "room_id", nullable = false)
-  private Room room;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id", nullable = false)
+    private Room room;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id", nullable = false)
-  private User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
 
-  @Column(name = "has_responded", nullable = false)
-  private boolean hasResponded = false;
+    @Column(name = "has_responded", nullable = false)
+    private boolean hasResponded = false;
 
-  @Column(name = "joined_at", nullable = false, updatable = false)
-  private LocalDateTime joinedAt;
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    private LocalDateTime joinedAt;
 
-  @Column(name = "responded_at")
-  private LocalDateTime respondedAt;
+    @Column(name = "responded_at")
+    private LocalDateTime respondedAt;
 
-  public Participant(Room room, User user) {
-    this.room = room;
-    this.user = user;
-    this.joinedAt = LocalDateTime.now();
-  }
+    public Participant(Room room, User user) {
+        this.room = room;
+        this.user = user;
+        this.joinedAt = LocalDateTime.now();
+    }
 
-  public void markResponded() {
-    this.hasResponded = true;
-    this.respondedAt = LocalDateTime.now();
-  }
-  
+    public void markResponded() {
+        this.hasResponded = true;
+        this.respondedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/com/example/timefit/domain/room/entity/Participant.java
+++ b/src/main/java/com/example/timefit/domain/room/entity/Participant.java
@@ -1,0 +1,52 @@
+package com.example.timefit.domain.room.entity;
+
+import com.example.timefit.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+  name = "participants",
+  uniqueConstraints = @UniqueConstraint(columnNames = {"room_id", "user_id"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Participant {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "room_id", nullable = false)
+  private Room room;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(name = "has_responded", nullable = false)
+  private boolean hasResponded = false;
+
+  @Column(name = "joined_at", nullable = false, updatable = false)
+  private LocalDateTime joinedAt;
+
+  @Column(name = "responded_at")
+  private LocalDateTime respondedAt;
+
+  public Participant(Room room, User user) {
+    this.room = room;
+    this.user = user;
+    this.joinedAt = LocalDateTime.now();
+  }
+
+  public void markResponded() {
+    this.hasResponded = true;
+    this.respondedAt = LocalDateTime.now();
+  }
+  
+}

--- a/src/main/java/com/example/timefit/domain/room/entity/Participant.java
+++ b/src/main/java/com/example/timefit/domain/room/entity/Participant.java
@@ -10,8 +10,8 @@ import java.time.LocalDateTime;
 
 @Entity
 @Table(
-        name = "participants",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"room_id", "user_id"})
+    name = "participants",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"room_id", "user_id"})
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/com/example/timefit/domain/room/entity/Room.java
+++ b/src/main/java/com/example/timefit/domain/room/entity/Room.java
@@ -19,6 +19,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Room {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id")

--- a/src/main/java/com/example/timefit/domain/room/repository/ParticipantRepository.java
+++ b/src/main/java/com/example/timefit/domain/room/repository/ParticipantRepository.java
@@ -7,8 +7,12 @@ import java.util.Optional;
 import java.util.List;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+
     Optional<Participant> findByRoom_IdAndUser_Id(Long roomId, Long userId);
+
     long countByRoom_Id(Long roomId);
+
     long countByRoom_IdAndHasRespondedTrue(Long roomId);
+
     List<Participant> findByRoom_Id(Long roomId);
 }

--- a/src/main/java/com/example/timefit/domain/room/repository/ParticipantRepository.java
+++ b/src/main/java/com/example/timefit/domain/room/repository/ParticipantRepository.java
@@ -4,7 +4,11 @@ import com.example.timefit.domain.room.entity.Participant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
+import java.util.List;
 
 public interface ParticipantRepository extends JpaRepository<Participant, Long> {
-    Optional<Participant> findByRoomIdAndUserId(Long roomId, Long userId);
+    Optional<Participant> findByRoom_IdAndUser_Id(Long roomId, Long userId);
+    long countByRoom_Id(Long roomId);
+    long countByRoom_IdAndHasRespondedTrue(Long roomId);
+    List<Participant> findByRoom_Id(Long roomId);
 }

--- a/src/main/java/com/example/timefit/domain/room/repository/ParticipantRepository.java
+++ b/src/main/java/com/example/timefit/domain/room/repository/ParticipantRepository.java
@@ -1,0 +1,10 @@
+package com.example.timefit.domain.room.repository;
+
+import com.example.timefit.domain.room.entity.Participant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ParticipantRepository extends JpaRepository<Participant, Long> {
+    Optional<Participant> findByRoomIdAndUserId(Long roomId, Long userId);
+}

--- a/src/main/java/com/example/timefit/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/timefit/domain/room/service/RoomService.java
@@ -6,11 +6,14 @@ import com.example.timefit.domain.room.dto.RoomCreateRequest;
 import com.example.timefit.domain.room.dto.RoomDeleteMessage;
 import com.example.timefit.domain.room.dto.RoomResponse;
 import com.example.timefit.domain.room.dto.RoomUpdateRequest;
+import com.example.timefit.domain.room.entity.Participant;
 import com.example.timefit.domain.room.entity.Room;
 import com.example.timefit.domain.room.entity.RoomDate;
 import com.example.timefit.domain.room.repository.RoomRepository;
 import com.example.timefit.domain.user.entity.User;
 import com.example.timefit.domain.user.repository.UserRepository;
+import com.example.timefit.domain.room.dto.RoomDetailResponse;
+import com.example.timefit.domain.room.repository.ParticipantRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,6 +31,7 @@ public class RoomService {
 
     private final RoomRepository roomRepository;
     private final UserRepository userRepository;
+    private final ParticipantRepository participantRepository;
 
     @Transactional
     public RoomResponse createRoom(RoomCreateRequest request, Long userId) {
@@ -117,11 +121,48 @@ public class RoomService {
 
     private LocalTime parseTime(String timeString) {
         if (timeString == null || timeString.isBlank()) {
-            return null;
+            throw new IllegalArgumentException("startTime/endTime은 필수입니다.");
         }
         if ("24:00".equals(timeString)) {
             return LocalTime.of(23, 59);
         }
         return LocalTime.parse(timeString, DateTimeFormatter.ofPattern("HH:mm"));
+    }
+
+    @Transactional(readOnly = true)
+    public RoomDetailResponse getRoomDetail(Long roomId, Long userId) {
+
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+
+        boolean isOwner = room.getOwner().getId().equals(userId);
+
+        boolean hasResponded = participantRepository.findByRoom_IdAndUser_Id(roomId, userId)
+                .map(Participant::isHasResponded) // Lombok getter 이름이 다르면 아래 참고
+                .orElse(false);
+
+        long totalParticipants = participantRepository.countByRoom_Id(roomId);
+        long respondedCount = participantRepository.countByRoom_IdAndHasRespondedTrue(roomId);
+
+        List<String> dates = room.getDates().stream()
+                .map(rd -> rd.getDate().toString())
+                .sorted()
+                .toList();
+
+        List<String> timeSlots = RoomResponse.generateTimeList(room.getStartTime(), room.getEndTime());
+
+        return new RoomDetailResponse(
+                room.getId(),
+                room.getTitle(),
+                dates,
+                timeSlots,
+                isOwner,
+                hasResponded,
+                totalParticipants,
+                respondedCount
+        );
     }
 }

--- a/src/main/java/com/example/timefit/domain/room/service/RoomService.java
+++ b/src/main/java/com/example/timefit/domain/room/service/RoomService.java
@@ -141,7 +141,7 @@ public class RoomService {
         boolean isOwner = room.getOwner().getId().equals(userId);
 
         boolean hasResponded = participantRepository.findByRoom_IdAndUser_Id(roomId, userId)
-                .map(Participant::isHasResponded) // Lombok getter 이름이 다르면 아래 참고
+                .map(Participant::isHasResponded)
                 .orElse(false);
 
         long totalParticipants = participantRepository.countByRoom_Id(roomId);

--- a/src/main/java/com/example/timefit/domain/timeslot/controller/TimeSlotController.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/controller/TimeSlotController.java
@@ -1,5 +1,48 @@
 package com.example.timefit.domain.timeslot.controller;
 
+import com.example.timefit.domain.timeslot.dto.TimeSlotRequest;
+import com.example.timefit.domain.timeslot.dto.TimeSlotResultsResponse;
+import com.example.timefit.domain.timeslot.dto.TimeSlotDetailResponse;
+import com.example.timefit.domain.timeslot.service.TimeSlotService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/rooms")
 public class TimeSlotController {
-  
+
+    private final TimeSlotService timeSlotService;
+
+    @PostMapping("/{roomId}/response")
+    public ResponseEntity<TimeSlotResultsResponse> submitTimeSlots(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal Long userId,
+            @RequestBody TimeSlotRequest request
+    ) {
+
+        TimeSlotResultsResponse response =
+                timeSlotService.submit(roomId, userId, request);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{roomId}/results")
+    public ResponseEntity<TimeSlotResultsResponse> getResults(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ResponseEntity.ok(timeSlotService.getResults(roomId, userId));
+    }
+
+    @GetMapping("/{roomId}/results/detail")
+    public ResponseEntity<TimeSlotDetailResponse> getResultDetail(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal Long userId,
+            @RequestParam String dateTime // "2026-02-10T13:00"
+    ) {
+        return ResponseEntity.ok(timeSlotService.getResultDetail(roomId, userId, dateTime));
+    }
 }

--- a/src/main/java/com/example/timefit/domain/timeslot/controller/TimeSlotController.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/controller/TimeSlotController.java
@@ -23,8 +23,8 @@ public class TimeSlotController {
             @RequestBody TimeSlotRequest request
     ) {
 
-        TimeSlotResultsResponse response =
-                timeSlotService.submit(roomId, userId, request);
+        TimeSlotResultsResponse response
+                = timeSlotService.submit(roomId, userId, request);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotDetailResponse.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotDetailResponse.java
@@ -2,15 +2,18 @@ package com.example.timefit.domain.timeslot.dto;
 
 import java.util.List;
 
-public record TimeSlotDetailResponse (
-  Long roomId,
-  String dateTime,
-  List<PersonInfo> availablePeople,
-  List<PersonInfo> unavailablePeople
-) {
-  public record PersonInfo(
-    Long userId,
-    String nickname,
-    String profileImageUrl
-  ) {}
+public record TimeSlotDetailResponse(
+        Long roomId,
+        String dateTime,
+        List<PersonInfo> availablePeople,
+        List<PersonInfo> unavailablePeople
+        ) {
+
+    public record PersonInfo(
+            Long userId,
+            String nickname,
+            String profileImageUrl
+            ) {
+
+    }
 }

--- a/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotDetailResponse.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotDetailResponse.java
@@ -1,0 +1,16 @@
+package com.example.timefit.domain.timeslot.dto;
+
+import java.util.List;
+
+public record TimeSlotDetailResponse (
+  Long roomId,
+  String dateTime,
+  List<PersonInfo> availablePeople,
+  List<PersonInfo> unavailablePeople
+) {
+  public record PersonInfo(
+    Long userId,
+    String nickname,
+    String profileImageUrl
+  ) {}
+}

--- a/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotDetailResponse.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotDetailResponse.java
@@ -3,17 +3,14 @@ package com.example.timefit.domain.timeslot.dto;
 import java.util.List;
 
 public record TimeSlotDetailResponse(
-        Long roomId,
-        String dateTime,
-        List<PersonInfo> availablePeople,
-        List<PersonInfo> unavailablePeople
-        ) {
-
+    Long roomId,
+    String dateTime,
+    List<PersonInfo> availablePeople,
+    List<PersonInfo> unavailablePeople
+) {
     public record PersonInfo(
-            Long userId,
-            String nickname,
-            String profileImageUrl
-            ) {
-
-    }
+        Long userId,
+        String nickname,
+        String profileImageUrl
+    ) {}
 }

--- a/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotRequest.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotRequest.java
@@ -1,5 +1,8 @@
 package com.example.timefit.domain.timeslot.dto;
 
-public class TimeSlotRequest {
-  
-}
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TimeSlotRequest(
+        List<LocalDateTime> availableSlots
+) {}

--- a/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotRequest.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotRequest.java
@@ -5,4 +5,6 @@ import java.util.List;
 
 public record TimeSlotRequest(
         List<LocalDateTime> availableSlots
-) {}
+        ) {
+
+}

--- a/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotRequest.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotRequest.java
@@ -4,7 +4,5 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record TimeSlotRequest(
-        List<LocalDateTime> availableSlots
-        ) {
-
-}
+    List<LocalDateTime> availableSlots
+) {}

--- a/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotResponse.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotResponse.java
@@ -1,5 +1,0 @@
-package com.example.timefit.domain.timeslot.dto;
-
-public class TimeSlotResponse {
-  
-}

--- a/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotResultsResponse.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotResultsResponse.java
@@ -1,0 +1,17 @@
+package com.example.timefit.domain.timeslot.dto;
+
+import java.util.List;
+
+public record TimeSlotResultsResponse(
+  Long roomId,
+  long totalParticipants,
+  long respondedCount,
+  List<String> bestSlots,
+  List<String> lastSlots,
+  List<SlotCount> slotCounts
+) {
+  public record SlotCount(
+    String dateTime,
+    int count
+  ) {}
+}

--- a/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotResultsResponse.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotResultsResponse.java
@@ -3,15 +3,18 @@ package com.example.timefit.domain.timeslot.dto;
 import java.util.List;
 
 public record TimeSlotResultsResponse(
-  Long roomId,
-  long totalParticipants,
-  long respondedCount,
-  List<String> bestSlots,
-  List<String> lastSlots,
-  List<SlotCount> slotCounts
-) {
-  public record SlotCount(
-    String dateTime,
-    int count
-  ) {}
+        Long roomId,
+        long totalParticipants,
+        long respondedCount,
+        List<String> bestSlots,
+        List<String> lastSlots,
+        List<SlotCount> slotCounts
+        ) {
+
+    public record SlotCount(
+            String dateTime,
+            int count
+            ) {
+
+    }
 }

--- a/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotResultsResponse.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/dto/TimeSlotResultsResponse.java
@@ -3,18 +3,15 @@ package com.example.timefit.domain.timeslot.dto;
 import java.util.List;
 
 public record TimeSlotResultsResponse(
-        Long roomId,
-        long totalParticipants,
-        long respondedCount,
-        List<String> bestSlots,
-        List<String> lastSlots,
-        List<SlotCount> slotCounts
-        ) {
-
+    Long roomId,
+    long totalParticipants,
+    long respondedCount,
+    List<String> bestSlots,
+    List<String> lastSlots,
+    List<SlotCount> slotCounts
+) {
     public record SlotCount(
-            String dateTime,
-            int count
-            ) {
-
-    }
+        String dateTime,
+        int count
+    ) {}
 }

--- a/src/main/java/com/example/timefit/domain/timeslot/entity/TimeSlot.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/entity/TimeSlot.java
@@ -1,39 +1,49 @@
 package com.example.timefit.domain.timeslot.entity;
 
+import java.time.LocalDateTime;
+
 import com.example.timefit.domain.room.entity.Participant;
-import jakarta.persistence.*;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Entity
 @Table(
-  name = "time_slots",
-  uniqueConstraints = @UniqueConstraint(columnNames = {"participant_id", "date_time"})
+        name = "time_slots",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"participant_id", "date_time"})
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TimeSlot {
-  
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "participant_id", nullable = false)
-  private Participant participant;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @Column(name = "date_time", nullable = false)
-  private LocalDateTime dateTime;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id", nullable = false)
+    private Participant participant;
 
-  @Column(name = "is_available", nullable = false)
-  private boolean isAvailable;
+    @Column(name = "date_time", nullable = false)
+    private LocalDateTime dateTime;
 
-  public TimeSlot(Participant participant, LocalDateTime dateTime, boolean isAvailable) {
-    this.participant = participant;
-    this.dateTime = dateTime;
-    this.isAvailable = isAvailable;
-  }
+    @Column(name = "is_available", nullable = false)
+    private boolean isAvailable;
+
+    public TimeSlot(Participant participant, LocalDateTime dateTime, boolean isAvailable) {
+        this.participant = participant;
+        this.dateTime = dateTime;
+        this.isAvailable = isAvailable;
+    }
 }

--- a/src/main/java/com/example/timefit/domain/timeslot/entity/TimeSlot.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/entity/TimeSlot.java
@@ -1,5 +1,39 @@
 package com.example.timefit.domain.timeslot.entity;
 
+import com.example.timefit.domain.room.entity.Participant;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(
+  name = "time_slots",
+  uniqueConstraints = @UniqueConstraint(columnNames = {"participant_id", "date_time"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TimeSlot {
   
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "participant_id", nullable = false)
+  private Participant participant;
+
+  @Column(name = "date_time", nullable = false)
+  private LocalDateTime dateTime;
+
+  @Column(name = "is_available", nullable = false)
+  private boolean isAvailable;
+
+  public TimeSlot(Participant participant, LocalDateTime dateTime, boolean isAvailable) {
+    this.participant = participant;
+    this.dateTime = dateTime;
+    this.isAvailable = isAvailable;
+  }
 }

--- a/src/main/java/com/example/timefit/domain/timeslot/repository/TimeSlotRepository.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/repository/TimeSlotRepository.java
@@ -1,14 +1,19 @@
 package com.example.timefit.domain.timeslot.repository;
 
-import com.example.timefit.domain.timeslot.entity.TimeSlot;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.example.timefit.domain.timeslot.entity.TimeSlot;
+
 public interface TimeSlotRepository extends JpaRepository<TimeSlot, Long> {
-  void deleteByParticipantId(Long participantId);
-  List<TimeSlot> findByParticipantRoomId(Long roomId);
-  List<TimeSlot> findByParticipantRoomIdAndDateTime(Long roomId, LocalDateTime dateTime);
-  boolean existsByParticipantIdAndDateTime(Long participantId, LocalDateTime dateTime);
+
+    void deleteByParticipantId(Long participantId);
+
+    List<TimeSlot> findByParticipantRoomId(Long roomId);
+
+    List<TimeSlot> findByParticipantRoomIdAndDateTime(Long roomId, LocalDateTime dateTime);
+
+    boolean existsByParticipantIdAndDateTime(Long participantId, LocalDateTime dateTime);
 }

--- a/src/main/java/com/example/timefit/domain/timeslot/repository/TimeSlotRepository.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/repository/TimeSlotRepository.java
@@ -1,5 +1,14 @@
 package com.example.timefit.domain.timeslot.repository;
 
-public class TimeSlotRepository {
-  
+import com.example.timefit.domain.timeslot.entity.TimeSlot;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface TimeSlotRepository extends JpaRepository<TimeSlot, Long> {
+  void deleteByParticipantId(Long participantId);
+  List<TimeSlot> findByParticipantRoomId(Long roomId);
+  List<TimeSlot> findByParticipantRoomIdAndDateTime(Long roomId, LocalDateTime dateTime);
+  boolean existsByParticipantIdAndDateTime(Long participantId, LocalDateTime dateTime);
 }

--- a/src/main/java/com/example/timefit/domain/timeslot/service/TimeSlotService.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/service/TimeSlotService.java
@@ -1,5 +1,199 @@
 package com.example.timefit.domain.timeslot.service;
 
+import com.example.timefit.domain.exeption.CustomException;
+import com.example.timefit.domain.exeption.ErrorCode;
+import com.example.timefit.domain.room.entity.Participant;
+import com.example.timefit.domain.room.entity.Room;
+import com.example.timefit.domain.room.repository.ParticipantRepository;
+import com.example.timefit.domain.room.repository.RoomRepository;
+import com.example.timefit.domain.timeslot.dto.TimeSlotDetailResponse;
+import com.example.timefit.domain.timeslot.dto.TimeSlotRequest;
+import com.example.timefit.domain.timeslot.dto.TimeSlotResultsResponse;
+import com.example.timefit.domain.timeslot.entity.TimeSlot;
+import com.example.timefit.domain.timeslot.repository.TimeSlotRepository;
+import com.example.timefit.domain.user.entity.User;
+import com.example.timefit.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
 public class TimeSlotService {
-  
+
+    private final TimeSlotRepository timeSlotRepository;
+    private final ParticipantRepository participantRepository;
+    private final RoomRepository roomRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public TimeSlotResultsResponse submit(Long roomId, Long userId, TimeSlotRequest request) {
+
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        Participant participant = participantRepository.findByRoom_IdAndUser_Id(roomId, userId)
+                .orElseGet(() -> participantRepository.save(new Participant(room, user)));
+
+        timeSlotRepository.deleteByParticipantId(participant.getId());
+
+        List<LocalDateTime> availableSlots =
+                (request == null || request.availableSlots() == null)
+                        ? Collections.emptyList()
+                        : request.availableSlots();
+
+        List<TimeSlot> toSave = availableSlots.stream()
+                .filter(Objects::nonNull)
+                .distinct()
+                .map(dt -> new TimeSlot(participant, dt, true))
+                .toList();
+
+        timeSlotRepository.saveAll(toSave);
+
+        participant.markResponded();
+
+        return getResults(roomId, userId);
+    }
+
+    @Transactional(readOnly = true)
+    public TimeSlotResultsResponse getResults(Long roomId, Long userId) {
+
+        roomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        long totalParticipants = participantRepository.countByRoom_Id(roomId);
+        long respondedCount = participantRepository.countByRoom_IdAndHasRespondedTrue(roomId);
+
+        AggregationResult agg = aggregate(roomId);
+
+        List<String> best = agg.bestSlots().stream().map(LocalDateTime::toString).toList();
+        List<String> last = agg.lastSlots().stream().map(LocalDateTime::toString).toList();
+
+        List<TimeSlotResultsResponse.SlotCount> slotCounts = agg.counts().entrySet().stream()
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> new TimeSlotResultsResponse.SlotCount(e.getKey().toString(), e.getValue()))
+                .toList();
+
+        return new TimeSlotResultsResponse(
+                roomId,
+                totalParticipants,
+                respondedCount,
+                best,
+                last,
+                slotCounts
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public TimeSlotDetailResponse getResultDetail(Long roomId, Long userId, String dateTimeStr) {
+
+        roomRepository.findById(roomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOM_NOT_FOUND));
+        userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        LocalDateTime dateTime;
+        try {
+            dateTime = LocalDateTime.parse(dateTimeStr);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException("dateTime 형식이 올바르지 않습니다. 예) 2026-02-10T13:00");
+        }
+
+        List<Participant> allParticipants = participantRepository.findByRoom_Id(roomId);
+
+        List<TimeSlot> availableSlots = timeSlotRepository.findByParticipantRoomIdAndDateTime(roomId, dateTime);
+
+        Set<Long> availableParticipantIds = availableSlots.stream()
+                .filter(TimeSlot::isAvailable)
+                .map(ts -> ts.getParticipant().getId())
+                .collect(Collectors.toSet());
+
+        List<TimeSlotDetailResponse.PersonInfo> availablePeople = allParticipants.stream()
+                .filter(p -> availableParticipantIds.contains(p.getId()))
+                .map(p -> new TimeSlotDetailResponse.PersonInfo(
+                        p.getUser().getId(),
+                        p.getUser().getNickname(),
+                        p.getUser().getProfileImageUrl()
+                ))
+                .toList();
+
+        List<TimeSlotDetailResponse.PersonInfo> unavailablePeople = allParticipants.stream()
+                .filter(p -> !availableParticipantIds.contains(p.getId()))
+                .map(p -> new TimeSlotDetailResponse.PersonInfo(
+                        p.getUser().getId(),
+                        p.getUser().getNickname(),
+                        p.getUser().getProfileImageUrl()
+                ))
+                .toList();
+
+        return new TimeSlotDetailResponse(
+                roomId,
+                dateTime.toString(),
+                availablePeople,
+                unavailablePeople
+        );
+    }
+
+    private AggregationResult aggregate(Long roomId) {
+
+        List<TimeSlot> roomSlots = timeSlotRepository.findByParticipantRoomId(roomId);
+
+        Map<LocalDateTime, Set<Long>> dtToParticipantIds = new HashMap<>();
+
+        for (TimeSlot ts : roomSlots) {
+            if (!ts.isAvailable()) continue;
+
+            LocalDateTime dt = ts.getDateTime();
+            Long participantId = ts.getParticipant().getId();
+
+            dtToParticipantIds
+                    .computeIfAbsent(dt, k -> new HashSet<>())
+                    .add(participantId);
+        }
+
+        if (dtToParticipantIds.isEmpty()) {
+          return new AggregationResult(List.of(), List.of(), Map.of());
+        }
+
+        Map<LocalDateTime, Integer> dtToCount = dtToParticipantIds.entrySet().stream()
+                .collect(Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> e.getValue().size()
+                ));
+
+        int max = dtToCount.values().stream().max(Integer::compareTo).orElse(0);
+
+        List<LocalDateTime> bestSlots = dtToCount.entrySet().stream()
+                .filter(e -> e.getValue() == max)
+                .map(Map.Entry::getKey)
+                .sorted()
+                .toList();
+
+        int second = max - 1;
+        List<LocalDateTime> lastSlots = (second <= 0)
+                ? List.of()
+                : dtToCount.entrySet().stream()
+                .filter(e -> e.getValue() == second)
+                .map(Map.Entry::getKey)
+                .sorted()
+                .toList();
+
+        return new AggregationResult(bestSlots, lastSlots, dtToCount);
+    }
+
+    private record AggregationResult(
+            List<LocalDateTime> bestSlots,
+            List<LocalDateTime> lastSlots,
+            Map<LocalDateTime, Integer> counts
+    ) {}
 }

--- a/src/main/java/com/example/timefit/domain/timeslot/service/TimeSlotService.java
+++ b/src/main/java/com/example/timefit/domain/timeslot/service/TimeSlotService.java
@@ -45,10 +45,11 @@ public class TimeSlotService {
 
         timeSlotRepository.deleteByParticipantId(participant.getId());
 
-        List<LocalDateTime> availableSlots =
-                (request == null || request.availableSlots() == null)
-                        ? Collections.emptyList()
-                        : request.availableSlots();
+        List<LocalDateTime> availableSlots = Collections.emptyList();
+
+        if (request.availableSlots() != null) {
+            availableSlots = request.availableSlots();
+        }
 
         List<TimeSlot> toSave = availableSlots.stream()
                 .filter(Objects::nonNull)
@@ -76,8 +77,13 @@ public class TimeSlotService {
 
         AggregationResult agg = aggregate(roomId);
 
-        List<String> best = agg.bestSlots().stream().map(LocalDateTime::toString).toList();
-        List<String> last = agg.lastSlots().stream().map(LocalDateTime::toString).toList();
+        List<String> best = agg.bestSlots().stream()
+                .map(LocalDateTime::toString)
+                .toList();
+
+        List<String> last = agg.lastSlots().stream()
+                .map(LocalDateTime::toString)
+                .toList();
 
         List<TimeSlotResultsResponse.SlotCount> slotCounts = agg.counts().entrySet().stream()
                 .sorted(Map.Entry.comparingByKey())
@@ -121,19 +127,19 @@ public class TimeSlotService {
         List<TimeSlotDetailResponse.PersonInfo> availablePeople = allParticipants.stream()
                 .filter(p -> availableParticipantIds.contains(p.getId()))
                 .map(p -> new TimeSlotDetailResponse.PersonInfo(
-                        p.getUser().getId(),
-                        p.getUser().getNickname(),
-                        p.getUser().getProfileImageUrl()
-                ))
+                p.getUser().getId(),
+                p.getUser().getNickname(),
+                p.getUser().getProfileImageUrl()
+        ))
                 .toList();
 
         List<TimeSlotDetailResponse.PersonInfo> unavailablePeople = allParticipants.stream()
                 .filter(p -> !availableParticipantIds.contains(p.getId()))
                 .map(p -> new TimeSlotDetailResponse.PersonInfo(
-                        p.getUser().getId(),
-                        p.getUser().getNickname(),
-                        p.getUser().getProfileImageUrl()
-                ))
+                p.getUser().getId(),
+                p.getUser().getNickname(),
+                p.getUser().getProfileImageUrl()
+        ))
                 .toList();
 
         return new TimeSlotDetailResponse(
@@ -148,52 +154,63 @@ public class TimeSlotService {
 
         List<TimeSlot> roomSlots = timeSlotRepository.findByParticipantRoomId(roomId);
 
-        Map<LocalDateTime, Set<Long>> dtToParticipantIds = new HashMap<>();
+        Map<LocalDateTime, Set<Long>> timeToParticipantIds = new HashMap<>();
 
-        for (TimeSlot ts : roomSlots) {
-            if (!ts.isAvailable()) continue;
+        for (TimeSlot slot : roomSlots) {
+            if (!slot.isAvailable()) {
+                continue;
+            }
 
-            LocalDateTime dt = ts.getDateTime();
-            Long participantId = ts.getParticipant().getId();
+            LocalDateTime time = slot.getDateTime();
+            Long participantId = slot.getParticipant().getId();
 
-            dtToParticipantIds
-                    .computeIfAbsent(dt, k -> new HashSet<>())
+            timeToParticipantIds
+                    .computeIfAbsent(time, key -> new HashSet<>())
                     .add(participantId);
         }
 
-        if (dtToParticipantIds.isEmpty()) {
-          return new AggregationResult(List.of(), List.of(), Map.of());
+        if (timeToParticipantIds.isEmpty()) {
+            return new AggregationResult(List.of(), List.of(), Map.of());
         }
 
-        Map<LocalDateTime, Integer> dtToCount = dtToParticipantIds.entrySet().stream()
+        Map<LocalDateTime, Integer> timeToCount = timeToParticipantIds.entrySet().stream()
                 .collect(Collectors.toMap(
                         Map.Entry::getKey,
                         e -> e.getValue().size()
                 ));
 
-        int max = dtToCount.values().stream().max(Integer::compareTo).orElse(0);
+        int max = timeToCount.values().stream()
+                .max(Integer::compareTo)
+                .orElse(0);
 
-        List<LocalDateTime> bestSlots = dtToCount.entrySet().stream()
+        List<LocalDateTime> bestSlots = timeToCount.entrySet().stream()
                 .filter(e -> e.getValue() == max)
                 .map(Map.Entry::getKey)
                 .sorted()
                 .toList();
 
         int second = max - 1;
-        List<LocalDateTime> lastSlots = (second <= 0)
-                ? List.of()
-                : dtToCount.entrySet().stream()
-                .filter(e -> e.getValue() == second)
-                .map(Map.Entry::getKey)
-                .sorted()
-                .toList();
 
-        return new AggregationResult(bestSlots, lastSlots, dtToCount);
+        List<LocalDateTime> lastSlots;
+
+        if (second <= 0) {
+            lastSlots = List.of();
+        } else {
+            lastSlots = timeToCount.entrySet().stream()
+                    .filter(e -> e.getValue() == second)
+                    .map(Map.Entry::getKey)
+                    .sorted()
+                    .toList();
+        }
+
+        return new AggregationResult(bestSlots, lastSlots, timeToCount);
     }
 
     private record AggregationResult(
             List<LocalDateTime> bestSlots,
             List<LocalDateTime> lastSlots,
             Map<LocalDateTime, Integer> counts
-    ) {}
+            ) {
+
+    }
 }

--- a/src/main/java/com/example/timefit/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/timefit/domain/user/controller/AuthController.java
@@ -56,5 +56,4 @@ public class AuthController {
             )
         );
     }
-
 }

--- a/src/main/java/com/example/timefit/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/timefit/domain/user/controller/UserController.java
@@ -33,16 +33,16 @@ public class UserController {
 
     @PutMapping("/me")
     public ResponseEntity<UserResponse> updateMyInfo(
-        Authentication authentication,
-        @RequestBody UserUpdateRequest request
+            Authentication authentication,
+            @RequestBody UserUpdateRequest request
     ) {
         Long userId = Long.valueOf(authentication.getName());
 
-        if(request.nickname() != null) {
+        if (request.nickname() != null) {
             userService.updateNickname(userId, request.nickname());
         }
 
-        if(request.profileImageUrl() != null) {
+        if (request.profileImageUrl() != null) {
             userService.updateProfileImage(userId, request.profileImageUrl());
         }
 

--- a/src/main/java/com/example/timefit/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/LoginRequest.java
@@ -1,6 +1,8 @@
 package com.example.timefit.domain.user.dto;
 
 public record LoginRequest(
-  String provider,
-  String accessToken
-) {}
+        String provider,
+        String accessToken
+        ) {
+
+}

--- a/src/main/java/com/example/timefit/domain/user/dto/LoginRequest.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/LoginRequest.java
@@ -1,8 +1,6 @@
 package com.example.timefit.domain.user.dto;
 
 public record LoginRequest(
-        String provider,
-        String accessToken
-        ) {
-
-}
+    String provider,
+    String accessToken
+) {}

--- a/src/main/java/com/example/timefit/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/LoginResponse.java
@@ -1,7 +1,9 @@
 package com.example.timefit.domain.user.dto;
 
 public record LoginResponse(
-    String accessToken,
-    String refreshToken,
-    UserResponse user
-) {}
+        String accessToken,
+        String refreshToken,
+        UserResponse user
+        ) {
+
+}

--- a/src/main/java/com/example/timefit/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/LoginResponse.java
@@ -1,9 +1,7 @@
 package com.example.timefit.domain.user.dto;
 
 public record LoginResponse(
-        String accessToken,
-        String refreshToken,
-        UserResponse user
-        ) {
-
-}
+    String accessToken,
+    String refreshToken,
+    UserResponse user
+) {}

--- a/src/main/java/com/example/timefit/domain/user/dto/LogoutResponse.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/LogoutResponse.java
@@ -3,6 +3,8 @@ package com.example.timefit.domain.user.dto;
 import java.time.Instant;
 
 public record LogoutResponse(
-  String message,
-  Instant timestamp
-) {}
+        String message,
+        Instant timestamp
+        ) {
+
+}

--- a/src/main/java/com/example/timefit/domain/user/dto/LogoutResponse.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/LogoutResponse.java
@@ -3,8 +3,6 @@ package com.example.timefit.domain.user.dto;
 import java.time.Instant;
 
 public record LogoutResponse(
-        String message,
-        Instant timestamp
-        ) {
-
-}
+    String message,
+    Instant timestamp
+) {}

--- a/src/main/java/com/example/timefit/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/UserResponse.java
@@ -3,12 +3,11 @@ package com.example.timefit.domain.user.dto;
 import com.example.timefit.domain.user.entity.User;
 
 public record UserResponse(
-        Long id,
-        String nickname,
-        String provider,
-        String profileImageUrl
-        ) {
-
+    Long id,
+    String nickname,
+    String provider,
+    String profileImageUrl
+) {
     public UserResponse(User user) {
         this(user.getId(), user.getNickname(), user.getProvider(), user.getProfileImageUrl());
     }

--- a/src/main/java/com/example/timefit/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/UserResponse.java
@@ -2,13 +2,14 @@ package com.example.timefit.domain.user.dto;
 
 import com.example.timefit.domain.user.entity.User;
 
-public record UserResponse (
-  Long id,
-  String nickname,
-  String provider,
-  String profileImageUrl
-) {
-  public UserResponse(User user) {
-    this(user.getId(), user.getNickname(), user.getProvider(), user.getProfileImageUrl());
-  }
+public record UserResponse(
+        Long id,
+        String nickname,
+        String provider,
+        String profileImageUrl
+        ) {
+
+    public UserResponse(User user) {
+        this(user.getId(), user.getNickname(), user.getProvider(), user.getProfileImageUrl());
+    }
 }

--- a/src/main/java/com/example/timefit/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/UserUpdateRequest.java
@@ -1,6 +1,8 @@
 package com.example.timefit.domain.user.dto;
 
 public record UserUpdateRequest(
-    String nickname,
-    String profileImageUrl
-) {}
+        String nickname,
+        String profileImageUrl
+        ) {
+
+}

--- a/src/main/java/com/example/timefit/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/example/timefit/domain/user/dto/UserUpdateRequest.java
@@ -1,8 +1,6 @@
 package com.example.timefit.domain.user.dto;
 
 public record UserUpdateRequest(
-        String nickname,
-        String profileImageUrl
-        ) {
-
-}
+    String nickname,
+    String profileImageUrl
+) {}

--- a/src/main/java/com/example/timefit/domain/user/entity/User.java
+++ b/src/main/java/com/example/timefit/domain/user/entity/User.java
@@ -18,45 +18,45 @@ import lombok.NoArgsConstructor;
 
 public class User {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
-  @Column(nullable = false, unique = true)
-  private String socialId;
+    @Column(nullable = false, unique = true)
+    private String socialId;
 
-  @Column(nullable = false)
-  private String provider;
+    @Column(nullable = false)
+    private String provider;
 
-  @Column(nullable = false)
-  private String nickname;
+    @Column(nullable = false)
+    private String nickname;
 
-  @Column
-  private String profileImageUrl;
+    @Column
+    private String profileImageUrl;
 
-  @Column(updatable = false)
-  private LocalDateTime createdAt;
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
 
-  @Column
-  private LocalDateTime updatedAt;
+    @Column
+    private LocalDateTime updatedAt;
 
-  public User(String socialId, String provider, String nickname) {
-    this.socialId = socialId;
-    this.provider = provider;
-    this.nickname = nickname;
-  }
-
-  public void updateNickname(String nickname) {
-    if (nickname == null || nickname.isBlank()) {
-      throw new IllegalArgumentException("nickname은 필수입니다.");
+    public User(String socialId, String provider, String nickname) {
+        this.socialId = socialId;
+        this.provider = provider;
+        this.nickname = nickname;
     }
-    this.nickname = nickname;
-    this.updatedAt = LocalDateTime.now();
-  }
 
-  public void updateProfileImage(String profileImageUrl) {
-    this.profileImageUrl = profileImageUrl;
-    this.updatedAt = LocalDateTime.now();
-  }
+    public void updateNickname(String nickname) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new IllegalArgumentException("nickname은 필수입니다.");
+        }
+        this.nickname = nickname;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateProfileImage(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+        this.updatedAt = LocalDateTime.now();
+    }
 
 }

--- a/src/main/java/com/example/timefit/domain/user/oauth/OAuth2UserInfo.java
+++ b/src/main/java/com/example/timefit/domain/user/oauth/OAuth2UserInfo.java
@@ -5,7 +5,10 @@ import java.util.Map;
 public interface OAuth2UserInfo {
 
     String getProvider();
+
     String getSocialId();
+
     String getNickname();
+
     Map<String, Object> getAttributes();
 }

--- a/src/main/java/com/example/timefit/domain/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/timefit/domain/user/repository/RefreshTokenRepository.java
@@ -5,8 +5,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
     Optional<RefreshToken> findByUserId(Long userId);
+
     Optional<RefreshToken> findByToken(String token);
+
     void deleteByUserId(Long userId);
 }
-

--- a/src/main/java/com/example/timefit/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/timefit/domain/user/repository/UserRepository.java
@@ -5,5 +5,6 @@ import com.example.timefit.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-  Optional<User> findBySocialId(String socialId);
+
+    Optional<User> findBySocialId(String socialId);
 }

--- a/src/main/java/com/example/timefit/domain/user/service/AuthService.java
+++ b/src/main/java/com/example/timefit/domain/user/service/AuthService.java
@@ -35,10 +35,14 @@ public class AuthService {
 
     public LoginResponse socialLogin(String provider, String accessToken) {
         return switch (provider.toUpperCase()) {
-            case "KAKAO" -> loginWithKakao(accessToken);
-            case "GOOGLE" -> loginWithGoogle(accessToken);
-            case "APPLE" -> loginWithApple(accessToken);
-            default -> throw new IllegalArgumentException("Unsupported provider: " + provider);
+            case "KAKAO" ->
+                loginWithKakao(accessToken);
+            case "GOOGLE" ->
+                loginWithGoogle(accessToken);
+            case "APPLE" ->
+                loginWithApple(accessToken);
+            default ->
+                throw new IllegalArgumentException("Unsupported provider: " + provider);
         };
     }
 
@@ -69,8 +73,8 @@ public class AuthService {
     @Transactional
     public void logout(String accessToken) {
 
-        if(!jwtTokenProvider.validateToken(accessToken)) {
-                throw new IllegalArgumentException("Invalid access token");
+        if (!jwtTokenProvider.validateToken(accessToken)) {
+            throw new IllegalArgumentException("Invalid access token");
         }
 
         Long userId = jwtTokenProvider.getUserId(accessToken);
@@ -84,17 +88,17 @@ public class AuthService {
 
         log.info("[AuthService] loginWithKakao start");
 
-        KakaoOAuth2UserInfo userInfo =
-                kakaoOAuthService.getUserInfo(kakaoAccessToken);
-        
+        KakaoOAuth2UserInfo userInfo
+                = kakaoOAuthService.getUserInfo(kakaoAccessToken);
+
         User user = userRepository.findBySocialId(userInfo.getSocialId())
                 .orElseGet(() -> userRepository.save(
-                        new User(
-                                userInfo.getSocialId(),
-                                userInfo.getProvider(),
-                                userInfo.getNickname()
-                        )
-                ));
+                new User(
+                        userInfo.getSocialId(),
+                        userInfo.getProvider(),
+                        userInfo.getNickname()
+                )
+        ));
 
         String accessToken = jwtTokenProvider.createAccessToken(user.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
@@ -110,17 +114,17 @@ public class AuthService {
 
     private LoginResponse loginWithGoogle(String googleAccessToken) {
 
-        GoogleOAuth2UserInfo userInfo =
-                googleOAuthService.getUserInfo(googleAccessToken);
+        GoogleOAuth2UserInfo userInfo
+                = googleOAuthService.getUserInfo(googleAccessToken);
 
         User user = userRepository.findBySocialId(userInfo.getSocialId())
                 .orElseGet(() -> userRepository.save(
-                        new User(
-                                userInfo.getSocialId(),
-                                userInfo.getProvider(),
-                                userInfo.getNickname()
-                        )
-                ));
+                new User(
+                        userInfo.getSocialId(),
+                        userInfo.getProvider(),
+                        userInfo.getNickname()
+                )
+        ));
 
         String accessToken = jwtTokenProvider.createAccessToken(user.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
@@ -136,17 +140,17 @@ public class AuthService {
 
     private LoginResponse loginWithApple(String identityToken) {
 
-        AppleOAuth2UserInfo userInfo =
-                appleOAuthService.getUserInfo(identityToken);
+        AppleOAuth2UserInfo userInfo
+                = appleOAuthService.getUserInfo(identityToken);
 
         User user = userRepository.findBySocialId(userInfo.getSocialId())
                 .orElseGet(() -> userRepository.save(
-                        new User(
-                                userInfo.getSocialId(),
-                                userInfo.getProvider(),
-                                generateDefaultNickname()
-                        )
-                ));
+                new User(
+                        userInfo.getSocialId(),
+                        userInfo.getProvider(),
+                        generateDefaultNickname()
+                )
+        ));
 
         String accessToken = jwtTokenProvider.createAccessToken(user.getId());
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());

--- a/src/main/java/com/example/timefit/domain/user/service/GoogleOAuthService.java
+++ b/src/main/java/com/example/timefit/domain/user/service/GoogleOAuthService.java
@@ -25,12 +25,13 @@ public class GoogleOAuthService {
 
         HttpEntity<Void> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<Map<String, Object>> response =
-                restTemplate.exchange(
+        ResponseEntity<Map<String, Object>> response
+                = restTemplate.exchange(
                         "https://www.googleapis.com/oauth2/v3/userinfo",
                         HttpMethod.GET,
                         entity,
-                        new ParameterizedTypeReference<Map<String, Object>>() {}
+                        new ParameterizedTypeReference<Map<String, Object>>() {
+                }
                 );
 
         log.info("[GoogleOAuthService] 구글 사용자 정보 조회 성공");

--- a/src/main/java/com/example/timefit/domain/user/service/KakaoOAuthService.java
+++ b/src/main/java/com/example/timefit/domain/user/service/KakaoOAuthService.java
@@ -24,12 +24,13 @@ public class KakaoOAuthService {
 
         HttpEntity<Void> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<Map<String, Object>> response =
-                restTemplate.exchange(
+        ResponseEntity<Map<String, Object>> response
+                = restTemplate.exchange(
                         "https://kapi.kakao.com/v2/user/me",
                         HttpMethod.GET,
                         entity,
-                        new ParameterizedTypeReference<Map<String, Object>>() {}
+                        new ParameterizedTypeReference<Map<String, Object>>() {
+                }
                 );
 
         log.info("[KakaoOAuthService] 카카오 사용자 정보 조회 성공");

--- a/src/main/java/com/example/timefit/domain/user/service/UserService.java
+++ b/src/main/java/com/example/timefit/domain/user/service/UserService.java
@@ -16,8 +16,8 @@ public class UserService {
 
     public User getUserById(Long userId) {
         return userRepository.findById(userId)
-                .orElseThrow(() ->
-                        new IllegalArgumentException("해당 유저를 찾을 수 없습니다. userId=" + userId)
+                .orElseThrow(()
+                        -> new IllegalArgumentException("해당 유저를 찾을 수 없습니다. userId=" + userId)
                 );
     }
 

--- a/src/main/java/com/example/timefit/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/timefit/global/config/SecurityConfig.java
@@ -23,17 +23,15 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         http
-            .csrf(csrf -> csrf.disable())
-            .formLogin(form -> form.disable())
-            .httpBasic(basic -> basic.disable())
-            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-            .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/api/auth/**").permitAll()
-                    .anyRequest().authenticated()
-            )
-
-            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/api/auth/**").permitAll()
+                .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/example/timefit/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/timefit/global/jwt/JwtTokenProvider.java
@@ -34,8 +34,8 @@ public class JwtTokenProvider implements InitializingBean {
 
     @Override
     public void afterPropertiesSet() {
-      this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
-      log.info("[JwtTokenProvider] Key initialized successfully.");
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+        log.info("[JwtTokenProvider] Key initialized successfully.");
     }
 
     public String createAccessToken(Long id) {
@@ -95,7 +95,7 @@ public class JwtTokenProvider implements InitializingBean {
         } catch (Exception e) {
             log.warn("[JwtTokenProvider] 토큰 검증 실패", e);
         }
-        
+
         return false;
     }
 


### PR DESCRIPTION
## 📋 변경 사항

<!-- 어떤 변경사항이 있는지 간단히 설명해주세요 -->
참여자 시간 선택 및 시간표 결과/결과 상세 기능을 구현했고, room 상세 조회 기능을 추가했습니다.
기존 Room dto및 service를 일부 수정하였습니다. 

## 🔗 관련 이슈

Closes #55 

## 📝 작업 내용

- [ ] 참여자 시간 선택 api 구현 (POST /api/rooms/{roomId}/response)
- [ ] 시간표 결과 조회/ 결과 상세 조회 api 구현 (GET /api/rooms/{roomId}/results) (GET /api/rooms/{roomId}/results/detail)
- [ ] 방 상세 조회 api 구현 (GET /api/rooms/{roomId})
- [ ] 시간표 집계 로직 구현

## 💡 참고사항 (선택)

<!-- 테스트 결과, 스크린샷, 리뷰 포인트, 참고 자료 등 추가 정보가 있다면 자유롭게 작성해주세요 -->

